### PR TITLE
Fix initial slide overshoot

### DIFF
--- a/src/stores/sliderStore.ts
+++ b/src/stores/sliderStore.ts
@@ -165,7 +165,8 @@ export function createSliderStore(
     direction: SliderState['direction'],
     newIndex: number
   ): number {
-    const { lowestVisibleIndex, itemsToDisplayInRow } = state;
+    const { isInitialNext, itemsToDisplayInRow, lowestVisibleIndex } = state;
+    const { totalItems } = get(derivedValues);
 
     switch (direction) {
       case 'next':
@@ -361,9 +362,20 @@ export function createSliderStore(
     itemWidth: SliderDerived['itemWidth']
   ): MediaContent[] {
     const { movies, itemsToDisplayInRow } = state;
+    const { totalItems } = get(derivedValues);
 
-    // Take enough items to handle next click plus a peek item
-    const initialItems = [...movies].slice(0, itemsToDisplayInRow * 2 + 1);
+    // Calculate how many items we need for initial content
+    const neededItems = itemsToDisplayInRow * 2 + 1;
+
+    let initialItems: Movie[];
+
+    if (totalItems >= neededItems) {
+      // Normal case: We have enough items
+      initialItems = [...movies].slice(0, neededItems);
+    } else {
+      // Special case: Not enough items, need to add peek item
+      initialItems = [...movies, movies[0]];
+    }
 
     // Map to required format
     return initialItems.map((movie) => ({

--- a/src/utils/sliderUtils.ts
+++ b/src/utils/sliderUtils.ts
@@ -219,8 +219,14 @@ export function calculateStyleString(
   paddingOffset: number = 8,
   contentRatio: number = 92
 ): string {
-  const { isSliderMoving, direction, itemsToDisplayInRow, movePercentage, hasMovedFromStart } =
-    state;
+  const {
+    direction,
+    hasMovedFromStart,
+    isSliderMoving,
+    itemsToDisplayInRow,
+    movePercentage,
+    movies,
+  } = state;
 
   // If row hasn't moved, return initial position
   if (!element || !hasMovedFromStart) {
@@ -231,6 +237,26 @@ export function calculateStyleString(
 
   // Handle initial next movement
   if (isInitialNextMovement(state)) {
+    const totalItems = movies.length;
+    // Check if we have fewer items than would fill two rows
+    if (totalItems < itemsToDisplayInRow * 2) {
+      // For the initial next click with fewer remaining items,
+      // we need to calculate the exact position that will show just the remaining items
+      const singleItemWidth = 100 / itemsToDisplayInRow;
+
+      // This is how many items we need to slide by
+      const remainingItems = totalItems - itemsToDisplayInRow;
+
+      // Calculate the exact position - this is the percentage of the container width
+      // that we need to translate by
+      const exactPosition = remainingItems * singleItemWidth;
+
+      // Apply any necessary adjustments for padding
+      const adjustedPosition = exactPosition * contentRatio;
+
+      return createTransformString(adjustedPosition);
+    }
+
     return createTransformString(basePosition - itemWidth);
   }
 


### PR DESCRIPTION
This PR adds a fix to handle the edge case where we need to adjust the way we construct our initial array — the `translate` calculation for initial `next` click — when the full dataset has fewer than `itemsToDisplayInRow 2 + 1` items (e.g. the Top 10 list). This PR:
- Updates `calculateStyleString` to calculate a unique `translate` value
- Updates `createInitialSliderContent` to add the first item in the dataset to the end of the array to act as the peek item on initial `next` click