### PR TITLE
Improve handling of rows without pagination and memoize `determineVisibleContent`

### DIFF
--- a/src/components/Row.svelte
+++ b/src/components/Row.svelte
@@ -87,7 +87,8 @@
    * @description Returns the appropriate component based on whether this is a top movies row,
    * a continue watching row with progress bars, or a standard row
    *
-   * @returns {typeof MediaItem | typeof MediaItemRanked | typeof MediaItemWithProgress} The component to use
+   * The component to use
+   * @returns {typeof MediaItem | typeof MediaItemRanked | typeof MediaItemWithProgress}
    */
   function getMediaItemComponent():
     | typeof MediaItem
@@ -135,11 +136,6 @@
     {#if totalItems === 0}
       <!-- Empty state when no movies are available -->
       <div class="row--empty">No movies available</div>
-    {:else if totalItems <= $state.itemsToDisplayInRow}
-      <!-- Simple rendering for small datasets -->
-      {#each movies as item (item.id)}
-        <MediaItem data={item} width={itemWidth} />
-      {/each}
     {:else}
       <!-- Complex rendering for larger datasets that need slider behavior -->
       <Slider

--- a/src/components/Slider.svelte
+++ b/src/components/Slider.svelte
@@ -54,6 +54,7 @@
     calculateContentRatio,
     calculateStyleString,
     getPaddingOffset,
+    isOnlyOnePage,
   } from '../utils/sliderUtils';
   import { createTouchHandlers } from '../utils/touchUtils';
 
@@ -83,7 +84,12 @@
   export let derived: SliderProps['derived'];
 
   // Add default values to prevent NaN during initialization
-  $: ({ currentPaginationIndex = 0, isSliderMoving = false, showPrev = false } = state || {});
+  $: ({
+    currentPaginationIndex = 0,
+    isSliderMoving = false,
+    itemsToDisplayInRow = 5,
+    showPrev = false,
+  } = state || {});
   $: ({
     itemWidth = 0,
     showControls = false,
@@ -179,7 +185,7 @@
   on:touchend={touchHandlers.handleTouchEnd}
 >
   <!-- Pagination indicators -->
-  {#if sliderContent.length > 0}
+  {#if !isOnlyOnePage(itemsToDisplayInRow, sliderContent.length)}
     <SliderPaginationIndicators
       indicators={paginationIndicators}
       currentIndex={currentPaginationIndex}

--- a/src/components/SliderPaginationIndicators.svelte
+++ b/src/components/SliderPaginationIndicators.svelte
@@ -61,7 +61,7 @@
     margin: -24px 0 12px;
     padding: 0;
     position: absolute;
-    right: 4%;
+    right: calc(4% + var(--item-gap));
     top: 0;
 
     /* Indicator */

--- a/src/stores/sliderStore.ts
+++ b/src/stores/sliderStore.ts
@@ -23,6 +23,9 @@ import type {
   SliderStore,
 } from '../types';
 
+// Utils
+import { generateSequentialIndices, isOnlyOnePage } from '../utils/sliderUtils';
+
 /**
  * Creates a slider store with state management and actions
  *
@@ -289,6 +292,11 @@ export function createSliderStore(
     const { lowestVisibleIndex, itemsToDisplayInRow, movies, hasMovedFromStart } = state;
     const totalItems = movies.length;
 
+    // Edge case: We only have one page of items. use all available items in order
+    if (isOnlyOnePage(itemsToDisplayInRow, totalItems)) {
+      return generateSequentialIndices(itemsToDisplayInRow);
+    }
+
     // Items visible when user clicks "prev"
     const left: number[] = [];
     // Display items
@@ -330,6 +338,9 @@ export function createSliderStore(
   function addPeekIndices(indices: number[], totalItems: SliderDerived['totalItems']): number[] {
     const result = [...indices];
 
+    // Edge case: We only have one page of items, do not add peek items
+    if (indices.length <= totalItems) return result;
+
     // Add trailing peek item
     const trailingIndex =
       indices[indices.length - 1] === totalItems - 1 ? 0 : indices[indices.length - 1] + 1;
@@ -361,19 +372,21 @@ export function createSliderStore(
     itemWidth: SliderDerived['itemWidth']
   ): MediaContent[] {
     const { movies, itemsToDisplayInRow } = state;
-    const { totalItems } = get(derivedValues);
+    const totalItems = movies.length;
 
     // Calculate how many items we need for initial content
     const neededItems = itemsToDisplayInRow * 2 + 1;
-
-    let initialItems: Movie[];
+    let initialItems: Movie[] = [];
 
     if (totalItems >= neededItems) {
       // Normal case: We have enough items
       initialItems = [...movies].slice(0, neededItems);
-    } else {
-      // Special case: Not enough items, need to add peek item
+    } else if (totalItems < neededItems && totalItems > itemsToDisplayInRow) {
+      // Special case: We have more than one page of items, but not enough for two full pages, add the first item as a peek
       initialItems = [...movies, movies[0]];
+    } else if (isOnlyOnePage(itemsToDisplayInRow, totalItems)) {
+      // Edge case: We only have one page of items. use all available items
+      initialItems = [...movies];
     }
 
     // Map to required format

--- a/src/stores/sliderStore.ts
+++ b/src/stores/sliderStore.ts
@@ -24,7 +24,7 @@ import type {
 } from '../types';
 
 // Utils
-import { generateSequentialIndices, isOnlyOnePage } from '../utils/sliderUtils';
+import { generateSequentialIndices, isOnlyOnePage, memoize } from '../utils';
 
 /**
  * Creates a slider store with state management and actions
@@ -88,7 +88,7 @@ export function createSliderStore(
       sliderContent = get(cachedContent);
     } else {
       // Calculate new content and update cache
-      sliderContent = determineVisibleContent($state, itemWidth);
+      sliderContent = memoizedDetermineVisibleContent($state, itemWidth);
       cachedContent.set(sliderContent);
     }
 
@@ -449,6 +449,8 @@ export function createSliderStore(
     state: SliderState,
     itemWidth: SliderDerived['itemWidth']
   ): MediaContent[] {
+    console.log('crab in my shoe mouth');
+
     const { movies, hasMovedFromStart } = state;
     const totalItems = movies.length;
 
@@ -469,6 +471,9 @@ export function createSliderStore(
     // Convert indices to renderable content
     return mapIndicesToContentItems(state, allIndices, itemWidth);
   }
+
+  // Create a memoized version of determineVisibleContent
+  const memoizedDetermineVisibleContent = memoize(determineVisibleContent);
 
   // -------------------------------------------------------------------------
   // PUBLIC ACTIONS
@@ -494,7 +499,7 @@ export function createSliderStore(
       // Make sure we have cached content before starting animation
       if (get(cachedContent).length === 0) {
         const itemWidth = 100 / currentState.itemsToDisplayInRow;
-        cachedContent.set(determineVisibleContent(currentState, itemWidth));
+        cachedContent.set(memoizedDetermineVisibleContent(currentState, itemWidth));
       }
 
       // Update state for animation
@@ -542,7 +547,7 @@ export function createSliderStore(
       // Make sure we have cached content before starting animation
       if (get(cachedContent).length === 0) {
         const itemWidth = 100 / currentState.itemsToDisplayInRow;
-        cachedContent.set(determineVisibleContent(currentState, itemWidth));
+        cachedContent.set(memoizedDetermineVisibleContent(currentState, itemWidth));
       }
 
       // Update state for animation

--- a/src/utils/helperUtils.ts
+++ b/src/utils/helperUtils.ts
@@ -14,6 +14,35 @@ export function filterDataWithBackdrops(data: Movie[]): Movie[] {
 }
 
 /**
+ * Creates a memoized version of a function
+ *
+ * @function memoize
+ * @description Caches results of function calls based on input arguments
+ *
+ * @param {Function} fn - Function to memoize
+ * @returns {Function} Memoized function
+ */
+export function memoize<T extends (...args: any[]) => any>(fn: T): T {
+  const cache = new Map();
+
+  return ((...args: Parameters<T>): ReturnType<T> => {
+    // Create a cache key from the stringified arguments
+    const key = JSON.stringify(args);
+
+    // If we have a cached result, return it
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+
+    // Otherwise, calculate the result and cache it
+    const result = fn(...args);
+    cache.set(key, result);
+
+    return result;
+  }) as T;
+}
+
+/**
  * Helper Utilities Module
  *
  * @module

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Utilities Barrel Module
+ *
+ * @module
+ * @description A barrel file that re-exports all utility functions from the various utility modules.
+ * This provides a centralized import point for all application utilities, allowing consumers
+ * to import from a single location rather than from individual files.
+ *
+ * The utilities exported from this module include error handling, general helpers, slider functionality,
+ * and touch interaction utilities that are used throughout the application to provide
+ * consistent behavior and reduce code duplication.
+ *
+ * @example
+ * // Instead of multiple imports:
+ * // import { handleError } from '../utils/errorUtils';
+ * // import { formatDate } from '../utils/helperUtils';
+ * // import { calculateStyleString } from '../utils/sliderUtils';
+ *
+ * // Use a single import:
+ * import { handleError, formatDate, calculateStyleString } from '../utils';
+ */
+
+export * from './errorUtils';
+export * from './helperUtils';
+export * from './sliderUtils';
+export * from './touchUtils';

--- a/src/utils/sliderUtils.ts
+++ b/src/utils/sliderUtils.ts
@@ -147,6 +147,19 @@ export function createTransformString(position: number): string {
 }
 
 /**
+ * Generates sequential indices
+ *
+ * @function generateSequentialIndices
+ * @description Creates an array of sequential indices
+ *
+ * @param {number} count - Number of indices to generate
+ * @returns {number[]} Array of sequential indices
+ */
+export function generateSequentialIndices(count: number): number[] {
+  return [...Array(count)].map((_, index) => index);
+}
+
+/**
  * Determines if this is an initial next movement that requires special handling
  *
  * @function isInitialNextMovement
@@ -165,6 +178,20 @@ export function isInitialNextMovement(state: SliderState): boolean {
   const { direction, isInitialNext, isSliderMoving } = state;
 
   return isSliderMoving && direction === 'next' && isInitialNext;
+}
+
+/**
+ * Checks if all content fits on a single page
+ *
+ * @function isOnlyOnePage
+ * @description Determines if we have a single-page scenario
+ *
+ * @param {number} itemsPerPage - Number of items that fit on one page
+ * @param {number} totalItems - Total number of items
+ * @returns {boolean} True if all content fits on a single page
+ */
+export function isOnlyOnePage(itemsPerPage: number, totalItems: number): boolean {
+  return totalItems <= itemsPerPage;
 }
 
 /**
@@ -228,16 +255,21 @@ export function calculateStyleString(
     movies,
   } = state;
 
-  // If row hasn't moved, return initial position
-  if (!element || !hasMovedFromStart) {
-    return createTransformString(0);
-  }
+  // Element doesn't exist in the DOM
+  if (!element) return createTransformString(0);
+
+  // Slider hasn't been scrolled yet
+  if (!hasMovedFromStart) return createTransformString(0);
+
+  // Not enough items to require scrolling
+  if (movies.length <= itemsToDisplayInRow) return createTransformString(0);
 
   const basePosition = calculateBasePosition(itemWidth, itemsToDisplayInRow, paddingOffset);
 
   // Handle initial next movement
   if (isInitialNextMovement(state)) {
     const totalItems = movies.length;
+
     // Check if we have fewer items than would fill two rows
     if (totalItems < itemsToDisplayInRow * 2) {
       // For the initial next click with fewer remaining items,


### PR DESCRIPTION
This PR improves that logic handling rows without pagination. This includes:
- Simplifying `Row.svelte` markup, leveraging `showControls` to simply disable the slider rather than using conditional markup logic
- Fixes pagination indicators show logic to hide indicators when only 1 page is rendered
- Adds `--item-gap` to `.slider__pagination-indicator` class to properly align the indicators with the items
- Adds `generateSequentialIndices` and `isOnlyOnePage` slider utils
- Adds a custom memo function and applies it to `determineVisibleContent` to limit expensive calls
- Add utils barrel module