### PR TITLE
Build `NavSubMenu` component to display nav links on smaller screens

### DIFF
--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -36,9 +36,9 @@
    *
    * @type {boolean}
    */
-  let isDropdownOpen = false;
-  let isMouseOverTrigger = false;
-  let isMouseOverDropdown = false;
+  let isDropdownOpen: boolean = false;
+  let isMouseOverTrigger: boolean = false;
+  let isMouseOverDropdown: boolean = false;
 
   /**
    * Transition duration in milliseconds

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -8,7 +8,13 @@
    *
    * @prop {NavItem[]} items - Array of navigation items to display
    * @prop {string} [currentItem="Home"] - The currently active navigation item
+   *
+   * @requires ../types
    */
+
+  // Components
+  import NavDropdown from './NavSubMenu.svelte';
+  import { fade } from 'svelte/transition';
 
   // Types
   import type { NavItem } from '../types';
@@ -24,12 +30,140 @@
   }
 
   export let items: NavPrimaryProps['items'];
+
+  /**
+   * State variables for dropdown interaction
+   *
+   * @type {boolean}
+   */
+  let isDropdownOpen = false;
+  let isMouseOverTrigger = false;
+  let isMouseOverDropdown = false;
+
+  /**
+   * Transition duration in milliseconds
+   * @constant {number}
+   */
+  const TRANSITION_DURATION = 150;
+
+  /**
+   * Handles mouse entering the trigger
+   *
+   * @function handleTriggerMouseEnter
+   * @description Updates state when mouse enters the dropdown trigger
+   *
+   * @example
+   * <button on:mouseenter={handleTriggerMouseEnter}>Trigger</button>
+   */
+  function handleTriggerMouseEnter(): void {
+    isMouseOverTrigger = true;
+    updateDropdownState();
+  }
+
+  /**
+   * Handles mouse leaving the trigger
+   *
+   * @function handleTriggerMouseLeave
+   * @description Updates state when mouse leaves the dropdown trigger
+   * with a delay to allow movement to the dropdown
+   *
+   * @example
+   * <button on:mouseleave={handleTriggerMouseLeave}>Trigger</button>
+   */
+  function handleTriggerMouseLeave(): void {
+    isMouseOverTrigger = false;
+
+    // setTimeout to allow the mouse to move to the dropdown
+    setTimeout(updateDropdownState, 350);
+  }
+
+  /**
+   * Handles mouse entering the dropdown
+   *
+   * @function handleDropdownMouseEnter
+   * @description Updates state when mouse enters the dropdown menu
+   *
+   * @example
+   * <div on:mouseenter={handleDropdownMouseEnter}>Dropdown</div>
+   */
+  function handleDropdownMouseEnter(): void {
+    isMouseOverDropdown = true;
+    updateDropdownState();
+  }
+
+  /**
+   * Handles mouse leaving the dropdown
+   *
+   * @function handleDropdownMouseLeave
+   * @description Updates state when mouse leaves the dropdown menu
+   * with a short delay to prevent flickering
+   *
+   * @example
+   * <div on:mouseleave={handleDropdownMouseLeave}>Dropdown</div>
+   */
+  function handleDropdownMouseLeave(): void {
+    isMouseOverDropdown = false;
+
+    // setTimeout to provide slight delay before closing the dropdown
+    setTimeout(updateDropdownState, 50);
+  }
+
+  /**
+   * Updates the dropdown visibility based on mouse position
+   *
+   * @function updateDropdownState
+   * @description Determines if the dropdown should be visible based on
+   * whether the mouse is over the trigger or the dropdown itself
+   */
+  function updateDropdownState(): void {
+    isDropdownOpen = isMouseOverTrigger || isMouseOverDropdown;
+  }
+
+  /**
+   * Handles keyboard interaction with the dropdown trigger
+   *
+   * @function handleKeydown
+   * @param {KeyboardEvent} event - The keyboard event
+   * @description Toggles the dropdown when Enter or Space is pressed
+   *
+   * @example
+   * <button on:keydown={handleKeydown}>Trigger</button>
+   */
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      isDropdownOpen = !isDropdownOpen;
+    }
+  }
 </script>
 
 <ul class="nav__primary">
-  <!-- Mobile Nav -->
+  <!-- Mobile Nav with dropdown -->
   <li class="nav__menu">
-    <span class="nav__menu--trigger">Browse</span>
+    <span
+      aria-haspopup="true"
+      aria-expanded={isDropdownOpen}
+      class="nav__menu--trigger"
+      role="button"
+      tabindex="0"
+      on:mouseenter={handleTriggerMouseEnter}
+      on:mouseleave={handleTriggerMouseLeave}
+    >
+      Browse
+    </span>
+
+    {#if isDropdownOpen}
+      <div
+        class="dropdown-container"
+        role="menu"
+        tabindex="0"
+        on:mouseenter={handleDropdownMouseEnter}
+        on:mouseleave={handleDropdownMouseLeave}
+        transition:fade={{ duration: TRANSITION_DURATION }}
+      >
+        <NavDropdown {items} isOpen={true} />
+      </div>
+    {/if}
   </li>
 
   <!-- Desktop Nav -->

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -144,7 +144,7 @@
     isMouseOverDropdown = false;
 
     // Clear any existing timeout
-    clearTimeouts(triggerTimeout);
+    clearTimeouts(dropdownTimeout);
 
     // setTimeout to provide slight delay before closing the dropdown
     // Type assertion to ensure setTimeout ID is treated as number across all environments

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -135,10 +135,28 @@
    * <button on:keydown={handleKeydown}>Trigger</button>
    */
   function handleKeydown(event: KeyboardEvent): void {
+    // Check if the dropdown is open and the key pressed is Enter or Space. If so, toggle the dropdown state
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       isDropdownOpen = !isDropdownOpen;
     }
+
+    // Check if the dropdown is open and the key pressed is Escape,.If so, close the dropdown
+    if (event.key === 'Escape' && isDropdownOpen) {
+      event.preventDefault();
+      isDropdownOpen = false;
+    }
+  }
+
+  /**
+   * Updates the dropdown visibility based on mouse position
+   *
+   * @function updateDropdownState
+   * @description Determines if the dropdown should be visible based on
+   * whether the mouse is over the trigger or the dropdown itself
+   */
+  function updateDropdownState(): void {
+    isDropdownOpen = isMouseOverTrigger || isMouseOverDropdown;
   }
 </script>
 
@@ -151,6 +169,7 @@
       class="nav__menu--trigger"
       role="button"
       tabindex="0"
+      on:keydown={handleKeydown}
       on:mouseenter={handleTriggerMouseEnter}
       on:mouseleave={handleTriggerMouseLeave}
     >

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -56,6 +56,13 @@
   const TRANSITION_DURATION = 150;
 
   /**
+   * Delay constants in milliseconds
+   * @constant {number}
+   */
+  const TRIGGER_TIMEOUT_DELAY = 350;
+  const DROPDOWN_TIMEOUT_DELAY = 50;
+
+  /**
    * Utility function to safely clear one or more timeouts
    *
    * @function clearTimeouts
@@ -106,7 +113,7 @@
 
     // setTimeout to allow the mouse to move to the dropdown
     // Type assertion to ensure setTimeout ID is treated as number across all environments
-    triggerTimeout = setTimeout(updateDropdownState, 350) as unknown as number;
+    triggerTimeout = setTimeout(updateDropdownState, TRIGGER_TIMEOUT_DELAY) as unknown as number;
   }
 
   /**
@@ -141,7 +148,7 @@
 
     // setTimeout to provide slight delay before closing the dropdown
     // Type assertion to ensure setTimeout ID is treated as number across all environments
-    dropdownTimeout = setTimeout(updateDropdownState, 50) as unknown as number;
+    dropdownTimeout = setTimeout(updateDropdownState, DROPDOWN_TIMEOUT_DELAY) as unknown as number;
   }
 
   /**

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -56,6 +56,25 @@
   const TRANSITION_DURATION = 150;
 
   /**
+   * Utility function to safely clear one or more timeouts
+   *
+   * @function clearTimeouts
+   * @param {...(number|null)} timeoutIds - One or more timeout IDs to clear
+   * @description Checks if each timeout ID is not null before clearing it
+   * @example
+   * // Clear a single timeout
+   * clearTimeouts(myTimeout);
+   *
+   * // Clear multiple timeouts
+   * clearTimeouts(triggerTimeout, dropdownTimeout);
+   */
+  export function clearTimeouts(...timeoutIds: (number | null)[]): void {
+    timeoutIds.forEach((id) => {
+      if (id !== null) clearTimeout(id);
+    });
+  }
+
+  /**
    * Handles mouse entering the trigger
    *
    * @function handleTriggerMouseEnter
@@ -83,9 +102,7 @@
     isMouseOverTrigger = false;
 
     // Clear any existing timeout
-    if (triggerTimeout !== null) {
-      clearTimeout(triggerTimeout);
-    }
+    clearTimeouts(triggerTimeout);
 
     // setTimeout to allow the mouse to move to the dropdown
     // Type assertion to ensure setTimeout ID is treated as number across all environments
@@ -120,9 +137,7 @@
     isMouseOverDropdown = false;
 
     // Clear any existing timeout
-    if (dropdownTimeout !== null) {
-      clearTimeout(dropdownTimeout);
-    }
+    clearTimeouts(triggerTimeout);
 
     // setTimeout to provide slight delay before closing the dropdown
     // Type assertion to ensure setTimeout ID is treated as number across all environments
@@ -172,8 +187,7 @@
    * and avoid executing callbacks after component unmount
    */
   onDestroy(() => {
-    if (triggerTimeout !== null) clearTimeout(triggerTimeout);
-    if (dropdownTimeout !== null) clearTimeout(dropdownTimeout);
+    clearTimeouts(triggerTimeout, dropdownTimeout);
   });
 </script>
 

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -13,7 +13,7 @@
    */
 
   // Components
-  import NavDropdown from './NavSubMenu.svelte';
+  import NavSubMenu from './NavSubMenu.svelte';
   import { fade } from 'svelte/transition';
 
   // Types
@@ -161,7 +161,7 @@
         on:mouseleave={handleDropdownMouseLeave}
         transition:fade={{ duration: TRANSITION_DURATION }}
       >
-        <NavDropdown {items} isOpen={true} />
+        <NavSubMenu {items} isOpen={true} />
       </div>
     {/if}
   </li>

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -9,12 +9,17 @@
    * @prop {NavItem[]} items - Array of navigation items to display
    * @prop {string} [currentItem="Home"] - The currently active navigation item
    *
+   * @requires svelte
+   * @requires svelte/transition
+   * @requires ./NavSubMenu
    * @requires ../types
    */
 
+  import { onDestroy } from 'svelte';
+  import { fade } from 'svelte/transition';
+
   // Components
   import NavSubMenu from './NavSubMenu.svelte';
-  import { fade } from 'svelte/transition';
 
   // Types
   import type { NavItem } from '../types';
@@ -158,6 +163,18 @@
   function updateDropdownState(): void {
     isDropdownOpen = isMouseOverTrigger || isMouseOverDropdown;
   }
+
+  /**
+   * Cleanup function that runs when component is destroyed
+   *
+   * @function onDestroy
+   * @description Clears any pending timeouts to prevent memory leaks
+   * and avoid executing callbacks after component unmount
+   */
+  onDestroy(() => {
+    if (triggerTimeout !== null) clearTimeout(triggerTimeout);
+    if (dropdownTimeout !== null) clearTimeout(dropdownTimeout);
+  });
 </script>
 
 <ul class="nav__primary">

--- a/src/components/NavPrimary.svelte
+++ b/src/components/NavPrimary.svelte
@@ -40,6 +40,10 @@
   let isMouseOverTrigger: boolean = false;
   let isMouseOverDropdown: boolean = false;
 
+  // Track timeouts to clear them if needed
+  let triggerTimeout: number | null = null;
+  let dropdownTimeout: number | null = null;
+
   /**
    * Transition duration in milliseconds
    * @constant {number}
@@ -73,8 +77,14 @@
   function handleTriggerMouseLeave(): void {
     isMouseOverTrigger = false;
 
+    // Clear any existing timeout
+    if (triggerTimeout !== null) {
+      clearTimeout(triggerTimeout);
+    }
+
     // setTimeout to allow the mouse to move to the dropdown
-    setTimeout(updateDropdownState, 350);
+    // Type assertion to ensure setTimeout ID is treated as number across all environments
+    triggerTimeout = setTimeout(updateDropdownState, 350) as unknown as number;
   }
 
   /**
@@ -104,19 +114,14 @@
   function handleDropdownMouseLeave(): void {
     isMouseOverDropdown = false;
 
-    // setTimeout to provide slight delay before closing the dropdown
-    setTimeout(updateDropdownState, 50);
-  }
+    // Clear any existing timeout
+    if (dropdownTimeout !== null) {
+      clearTimeout(dropdownTimeout);
+    }
 
-  /**
-   * Updates the dropdown visibility based on mouse position
-   *
-   * @function updateDropdownState
-   * @description Determines if the dropdown should be visible based on
-   * whether the mouse is over the trigger or the dropdown itself
-   */
-  function updateDropdownState(): void {
-    isDropdownOpen = isMouseOverTrigger || isMouseOverDropdown;
+    // setTimeout to provide slight delay before closing the dropdown
+    // Type assertion to ensure setTimeout ID is treated as number across all environments
+    dropdownTimeout = setTimeout(updateDropdownState, 50) as unknown as number;
   }
 
   /**

--- a/src/components/NavSubMenu.svelte
+++ b/src/components/NavSubMenu.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  /**
+   * NavSubMenu Component
+   *
+   * @component
+   * @description Dropdown menu that appears when hovering over the "Browse" option
+   * in the condensed navigation. Displays a list of navigation options in a floating
+   * panel with a dark, semi-transparent background.
+   *
+   * @prop {boolean} [isOpen=false] - Whether the dropdown menu is currently open
+   * @prop {NavItem[]} [items=[]] - Array of navigation items to display in the dropdown
+   *
+   * @requires ../types
+   */
+
+  // Types
+  import type { NavItem } from '../types';
+
+  /**
+   * Props for the NavSubMenu component
+   *
+   * @typedef {Object} NavSubMenuProps
+   * @property {boolean} isOpen - Whether the dropdown menu is currently open
+   * @property {NavItem[]} items - Array of navigation items to display
+   */
+  interface NavSubMenuProps {
+    isOpen: boolean;
+    items: NavItem[];
+  }
+
+  /**
+   * Controls the visibility of the dropdown menu
+   * When true, the menu is visible with full opacity
+   * When false, the menu is hidden
+   *
+   * @type {boolean}
+   * @default false
+   */
+  export let isOpen: NavSubMenuProps['isOpen'] = false;
+
+  /**
+   * The navigation items to display in the dropdown menu
+   * Each item can have a current/active state that affects its styling
+   *
+   * @type {NavItem[]}
+   * @default []
+   */
+  export let items: NavSubMenuProps['items'] = [];
+</script>
+
+<div class="nav__sub-menu" class:nav__sub-menu--open={isOpen}>
+  <!-- The arrow pointing to the trigger -->
+  <div class="callout-arrow" />
+
+  <!-- The top bar of the dropdown -->
+  <div class="topbar" />
+
+  <!-- The list of navigation items -->
+  <ul class="sub-menu__list">
+    {#each items as item}
+      <li class="sub-menu__list-item" class:sub-menu__list-item--current={item.isCurrent}>
+        {item.label}
+      </li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  /* Main dropdown container with semi-transparent background */
+  .nav__sub-menu {
+    background-color: rgba(0, 0, 0, 0.9);
+    border: 1px solid hsla(0, 0%, 100%, 0.15);
+    box-sizing: border-box;
+    color: #fff;
+    cursor: default;
+    font-size: 13px;
+    line-height: 21px;
+    opacity: 0;
+    position: absolute;
+    top: 64px;
+    margin-left: -90px;
+  }
+
+  /* Triangle indicator pointing to the trigger element */
+  .callout-arrow {
+    border: 7px solid transparent;
+    border-bottom-color: #e5e5e5;
+    height: 0;
+    left: 50%;
+    margin-left: -7px;
+    position: absolute;
+    top: -16px;
+    width: 0;
+  }
+
+  /* Horizontal accent line at the top of the dropdown */
+  .topbar {
+    background: #e5e5e5;
+    height: 2px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: -2px;
+  }
+
+  /* Visible state for the dropdown */
+  .nav__sub-menu--open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  /* Container for the navigation items list */
+  .sub-menu__list {
+    height: auto;
+    padding: 0;
+  }
+
+  /* Individual navigation item in the dropdown */
+  .sub-menu__list-item {
+    display: block;
+    line-height: 24px;
+    align-items: center;
+    color: #b3b3b3;
+    display: flex;
+    height: 50px;
+    justify-content: center;
+    position: relative;
+    transition: background-color 0.4s;
+    width: 260px;
+  }
+
+  /* Current/active navigation item and hover state */
+  .sub-menu__list-item--current,
+  .sub-menu__list-item:hover {
+    font-weight: 700;
+    color: #fff;
+  }
+</style>


### PR DESCRIPTION
This PR builds the `NavSubMenu` component to display nav links on smaller screens. This component works as follows:
- On smaller screens the nav menu collapses to only show `Browse`
- When the `Browse` element is hovered it triggers the display of the submenu
- The menu contains the full assortment of nav links, center justified
- The current item is highlighted (bold white text) (set to `Home` as there are no other pages)
- Hovering a nav link will give it the same active styling as the current item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the primary navigation with an interactive dropdown menu that responds to hovering and keyboard inputs, improving accessibility and user experience.
  - Introduced a new submenu component that displays navigation options in a condensed format with dynamic styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->