### PR TITLE
Update BaseIcon and ChevronIcon components

### DIFF
--- a/src/components/icons/BaseIcon.svelte
+++ b/src/components/icons/BaseIcon.svelte
@@ -30,12 +30,14 @@
     className?: string;
     height?: string;
     name: keyof typeof ICON_PATHS;
+    style?: string;
     width?: string;
   }
 
   export let className: BaseIconProps['className'] = '';
   export let height: BaseIconProps['height'] = '24';
   export let name: BaseIconProps['name'];
+  export let style: BaseIconProps['style'] = '';
   export let width: BaseIconProps['width'] = '24';
 
   $: path = ICON_PATHS[name]?.path || '';
@@ -43,15 +45,15 @@
 </script>
 
 <svg
-  xmlns="http://www.w3.org/2000/svg"
-  fill="none"
-  role="img"
-  {viewBox}
-  {width}
-  {height}
-  data-icon={name}
   aria-hidden="true"
   class={className}
+  data-icon={name}
+  role="img"
+  xmlns="http://www.w3.org/2000/svg"
+  {height}
+  {style}
+  {viewBox}
+  {width}
 >
   {#if path}
     <path fill-rule="evenodd" clip-rule="evenodd" d={path} fill="currentColor" />

--- a/src/components/icons/ChevronIcon.svelte
+++ b/src/components/icons/ChevronIcon.svelte
@@ -7,7 +7,7 @@
    * Can be rendered as either left-pointing or right-pointing and in different sizes.
    *
    * @prop {string} [className=""] - Additional CSS classes to apply to the SVG
-   * @prop {('left'|'right')} direction - The direction the chevron should point
+   * @prop {'left'|'right'|'up'|'down'} direction - The direction the chevron should point
    * @prop {('default'|'small')} [variant="default"] - Size variant of the chevron
    */
 
@@ -16,35 +16,94 @@
    *
    * @typedef {Object} ChevronIconProps
    * @property {string} [className=""] - Additional CSS classes to apply to the SVG
-   * @property {'left'|'right'} direction - The direction the chevron should point
+   * @property {'left'|'right'|'up'|'down'} direction - The direction the chevron should point
    * @property {'default'|'small'} [variant="default"] - Size variant of the chevron
    */
   interface ChevronIconProps {
     className?: string;
-    direction: 'left' | 'right';
+    direction: 'down' | 'left' | 'right' | 'up';
     variant?: 'default' | 'small';
   }
 
   export let className: ChevronIconProps['className'] = '';
   export let direction: ChevronIconProps['direction'];
+  export let style: string = '';
   export let variant: ChevronIconProps['variant'] = 'default';
+
+  /**
+   * Get the polyline points based on the direction
+   *
+   * @function getPolylinePoints
+   * @description Returns the appropriate polyline points for the specified direction
+   *
+   * @param {ChevronIconProps['direction']} dir - The direction of the chevron
+   * @returns {string} The polyline points as a string
+   */
+  function getPolylinePoints(dir: ChevronIconProps['direction']): string {
+    switch (dir) {
+      case 'left':
+        return '9 22 1 12 9 2';
+
+      case 'right':
+        return '1 22 9 12 1 2';
+
+      case 'up':
+        return '2 9 12 1 22 9';
+
+      case 'down':
+        return '2 1 12 9 22 1';
+
+      // Default to right direction if an invalid direction is provided
+      default:
+        return '1 22 9 12 1 2';
+    }
+  }
+
+  /**
+   * Get the appropriate viewBox based on the direction
+   *
+   * @function getViewBox
+   * @description Returns the appropriate SVG viewBox for the specified direction
+   *
+   * @param {ChevronIconProps['direction']} dir - The direction of the chevron
+   * @returns {string} The viewBox dimensions as a string
+   */
+  function getViewBox(dir: ChevronIconProps['direction']): string {
+    // For vertical directions (up/down), swap the dimensions
+    return dir === 'up' || dir === 'down' ? '0 0 24 10' : '0 0 10 24';
+  }
+
+  /**
+   * Determine if the icon needs special CSS for vertical orientation
+   *
+   * @function isVertical
+   * @description Returns true if the direction is vertical (up/down)
+   *
+   * @param {ChevronIconProps['direction']} dir - The direction of the chevron
+   * @returns {boolean} True if the direction is vertical
+   */
+  function isVertical(dir: ChevronIconProps['direction']): boolean {
+    return dir === 'up' || dir === 'down';
+  }
+
+  // Compute the polyline points and viewBox
+  const points = getPolylinePoints(direction);
+  const viewBox = getViewBox(direction);
+  const verticalClass = isVertical(direction) ? 'icon-chevron--vertical' : '';
 </script>
 
 <svg
-  class={`icon-chevron--${variant} ${className}`}
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 10 24"
+  class={`icon-chevron--${variant} ${verticalClass} ${className}`}
   fill="none"
   stroke="currentColor"
-  stroke-width="3"
   stroke-linecap="round"
   stroke-linejoin="round"
+  stroke-width="3"
+  {style}
+  xmlns="http://www.w3.org/2000/svg"
+  {viewBox}
 >
-  {#if direction === 'left'}
-    <polyline points="9 22 1 12 9 2"></polyline>
-  {:else}
-    <polyline points="1 22 9 12 1 2"></polyline>
-  {/if}
+  <polyline {points}></polyline>
 </svg>
 
 <style>
@@ -62,6 +121,20 @@
   .icon-chevron--small {
     height: 0.85vw;
     stroke-width: 6;
+    width: 0.85vw;
+  }
+
+  /* Adjust dimensions for vertical chevrons (up/down) */
+  .icon-chevron--vertical.icon-chevron--default {
+    height: var(--override-height, 1.21vw);
+    min-width: 16px;
+    min-height: 6px;
+    stroke-width: 2;
+    width: var(--override-width, 3.08vw);
+  }
+
+  .icon-chevron--vertical.icon-chevron--small {
+    height: 0.85vw;
     width: 0.85vw;
   }
 </style>


### PR DESCRIPTION
This PR adds a `style` prop to `BaseIcon` and updates `ChrevronIcon` to also render vertical (up/down) chevrons with the requisite logic to ensure the correct chevron is rendered