### PR TITLE
Build mediaDetailsService

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Services Barrel Module
+ *
+ * @module
+ * @description A barrel file that re-exports all services from the various service modules.
+ * This provides a centralized import point for all application services, allowing consumers
+ * to import from a single location rather than from individual files.
+ *
+ * @example
+ * // Instead of multiple imports:
+ * // import { fetchMediaDetailsBatch } from '@services/mediaDetailsService';
+ * // import { fetchMediaByCategory } from '@services/mediasService';
+ *
+ * // Use a single import:
+ * import { fetchMediaDetailsBatch, fetchMediaByCategory } from '@services';
+ */
+
+export * from './apiService';
+export * from './mediaDetailsService';
+export * from './mediaService';

--- a/src/services/mediaDetailsService.ts
+++ b/src/services/mediaDetailsService.ts
@@ -1,0 +1,424 @@
+/**
+ * Media Details Service System
+ *
+ * @module
+ * @description Provides comprehensive service functions for fetching, caching, and formatting
+ * detailed media information from the TMDB API. Implements intelligent batch processing,
+ * efficient caching mechanisms, and data transformation utilities for enhanced media
+ * presentation throughout the application.
+ *
+ * The service includes:
+ * - Intelligent batch fetching with concurrent request management
+ * - Memory-efficient caching system with duplicate request prevention
+ * - Content rating extraction for US market compliance
+ * - Runtime and episode formatting for user-friendly display
+ * - Media type-specific data handling and transformation
+ * - Error handling and recovery mechanisms
+ * - Performance optimization through request batching and throttling
+ *
+ * @requires ./apiService
+ * @requires module:@types
+ */
+
+// Services
+import api from './apiService';
+
+// Types
+import type { AnyMedia } from '@types';
+
+// Cache to store fetched details
+const detailsCache = new Map<number, any>();
+
+// Set to track media IDs that are currently being fetched
+const pendingFetches = new Set<number>();
+
+// Maximum number of items to fetch in a single batch
+const MAX_BATCH_SIZE = 10;
+
+/**
+ * Fetches detailed information for a batch of media items
+ *
+ * @async
+ * @function fetchMediaDetailsBatch
+ * @description Efficiently fetches detailed information for multiple media items using
+ * intelligent batch processing and caching. Prevents duplicate requests, manages
+ * concurrent fetches, and implements throttling to avoid API rate limits. Extracts
+ * comprehensive media details including content ratings, genres, runtime, and
+ * episode information with proper error handling and recovery.
+ *
+ * @param {AnyMedia[]} mediaItems - Array of media items to fetch details for
+ *
+ * @returns {Promise<Map<number, any>>} A promise that resolves to a Map of media IDs to their detailed information
+ *
+ * @example
+ * // Fetch details for a carousel of media items
+ * const mediaCarousel = await fetchMediaByCategory('fetchTrending');
+ * const detailsMap = await fetchMediaDetailsBatch(mediaCarousel);
+ *
+ * mediaCarousel.forEach(media => {
+ *   const details = detailsMap.get(media.id);
+ *   if (details) {
+ *     console.log(`${media.name}: ${details.contentRating}, ${getFormattedDuration(details)}`);
+ *   }
+ * });
+ *
+ * @example
+ * // Batch fetch with error handling
+ * try {
+ *   const mediaItems = [...netflixOriginals, ...trendingMovies];
+ *   const detailsCache = await fetchMediaDetailsBatch(mediaItems);
+ *
+ *   if (detailsCache.size > 0) {
+ *     updateMediaCarouselWithDetails(mediaItems, detailsCache);
+ *   }
+ * } catch (error) {
+ *   console.error('Batch fetch failed:', error);
+ *   displayMediaWithoutDetails(mediaItems);
+ * }
+ *
+ * @example
+ * // Progressive loading for large datasets
+ * async function loadAllMediaDetails(allMedia: AnyMedia[]) {
+ *   const chunks = [];
+ *   for (let i = 0; i < allMedia.length; i += 50) {
+ *     chunks.push(allMedia.slice(i, i + 50));
+ *   }
+ *
+ *   for (const chunk of chunks) {
+ *     await fetchMediaDetailsBatch(chunk);
+ *     // Allow UI to update between batches
+ *     await new Promise(resolve => setTimeout(resolve, 200));
+ *   }
+ * }
+ */
+export async function fetchMediaDetailsBatch(mediaItems: AnyMedia[]): Promise<Map<number, any>> {
+  // Filter out items that are already in the cache or being fetched
+  const itemsToFetch = mediaItems.filter(
+    (item) => !detailsCache.has(item.id) && !pendingFetches.has(item.id)
+  );
+
+  // If all items are already cached or being fetched, return the cache
+  if (itemsToFetch.length === 0) {
+    return detailsCache;
+  }
+
+  // Limit batch size to prevent too many simultaneous requests
+  const batchItems = itemsToFetch.slice(0, MAX_BATCH_SIZE);
+
+  // Mark these items as pending
+  batchItems.forEach((item) => pendingFetches.add(item.id));
+
+  // Create an array of promises for each item that needs to be fetched
+  const fetchPromises = batchItems.map(async (media) => {
+    try {
+      // Determine if it's a movie or TV show
+      const mediaType = media.media_type;
+      const isMovie = mediaType === 'movie';
+
+      // Construct the endpoint with append_to_response to get everything in one request
+      const appendParam = isMovie ? 'release_dates' : 'content_ratings';
+      const endpoint = `/${mediaType}/${media.id}?api_key=${
+        import.meta.env.VITE_API_KEY
+      }&append_to_response=${appendParam}`;
+
+      // Fetch the data
+      const { data } = await api.get(endpoint);
+
+      // Extract content rating
+      let contentRating = 'N/A';
+
+      if (isMovie && data.release_dates) {
+        // Find US rating if available
+        const usReleases = data.release_dates.results.find(
+          (result: { iso_3166_1: string; release_dates: Array<{ certification: string }> }) =>
+            result.iso_3166_1 === 'US'
+        );
+
+        if (usReleases) {
+          contentRating = usReleases.release_dates[0].certification;
+        }
+      } else if (!isMovie && data.content_ratings) {
+        // Find US rating if available
+        const usRating = data.content_ratings.results.find(
+          (result: { iso_3166_1: string; rating: string }) => result.iso_3166_1 === 'US'
+        );
+
+        if (usRating) {
+          contentRating = usRating.rating;
+        }
+      }
+
+      // Extract only the needed fields
+      const details = {
+        // Basic information
+        contentRating,
+        genres: data.genres || [],
+        mediaType,
+        mediaTitleType: data.type,
+
+        // Movie-specific information
+        runtime: mediaType === 'movie' ? data.runtime || 0 : null,
+
+        // TV-specific information
+        number_of_episodes: mediaType === 'tv' ? data.number_of_episodes || 0 : null,
+        number_of_seasons: mediaType === 'tv' ? data.number_of_seasons || 0 : null,
+
+        // For collections/franchises
+        belongs_to_collection: data.belongs_to_collection || null,
+      };
+
+      // Add to cache
+      detailsCache.set(media.id, details);
+
+      return { id: media.id, details };
+    } catch (err) {
+      console.error(`Error fetching details for media ID ${media.id}:`, err);
+      return { id: media.id, details: null };
+    } finally {
+      // Remove from pending set regardless of success or failure
+      pendingFetches.delete(media.id);
+    }
+  });
+
+  // Wait for all fetch operations to complete
+  await Promise.all(fetchPromises);
+
+  // If there are more items to fetch, schedule the next batch
+  if (itemsToFetch.length > MAX_BATCH_SIZE) {
+    // Use setTimeout to give the browser a chance to breathe
+    setTimeout(() => {
+      fetchMediaDetailsBatch(itemsToFetch.slice(MAX_BATCH_SIZE));
+    }, 100);
+  }
+
+  // Return the updated cache
+  return detailsCache;
+}
+
+/**
+ * Formats runtime from minutes to hours and minutes
+ *
+ * @function formatRuntime
+ * @description Converts movie runtime from minutes to a user-friendly hours and minutes
+ * format. Handles edge cases for movies with no runtime data, movies under an hour,
+ * and movies with exact hour durations. Provides consistent formatting across the
+ * application for runtime display in media cards and detail views.
+ *
+ * @param {number} minutes - Runtime in minutes from TMDB API
+ *
+ * @returns {string} Formatted runtime string in "Xh Ym", "Xh", "Ym", or "N/A" format
+ *
+ * @example
+ * // Format various runtime scenarios
+ * console.log(formatRuntime(142)); // "2h 22m"
+ * console.log(formatRuntime(120)); // "2h"
+ * console.log(formatRuntime(45));  // "45m"
+ * console.log(formatRuntime(0));   // "N/A"
+ * console.log(formatRuntime(null)); // "N/A"
+ *
+ * @example
+ * // Use in media card component
+ * function MediaCard({ media, details }) {
+ *   const runtime = details?.runtime ? formatRuntime(details.runtime) : 'N/A';
+ *
+ *   return (
+ *     <div className="media-card">
+ *       <h3>{media.name}</h3>
+ *       <p>Runtime: {runtime}</p>
+ *     </div>
+ *   );
+ * }
+ *
+ * @example
+ * // Batch format for multiple movies
+ * const movieRuntimes = movies.map(movie => ({
+ *   title: movie.name,
+ *   duration: formatRuntime(movie.details?.runtime)
+ * }));
+ */
+export function formatRuntime(minutes: number): string {
+  if (!minutes) return 'N/A';
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours === 0) {
+    return `${remainingMinutes}m`;
+  }
+
+  if (remainingMinutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+/**
+ * Formats TV show seasons/episodes information
+ *
+ * @function formatTVInfo
+ * @description Formats TV show season and episode information into user-friendly
+ * display strings. Handles single season shows by displaying episode count,
+ * multi-season shows by displaying season count, and edge cases with missing
+ * or zero values. Provides consistent formatting for TV show metadata display.
+ *
+ * @param {number} seasons - Number of seasons from TMDB API
+ * @param {number} episodes - Number of episodes from TMDB API
+ *
+ * @returns {string} Formatted TV show information string
+ *
+ * @example
+ * // Format various TV show scenarios
+ * console.log(formatTVInfo(1, 10));  // "10 Episodes"
+ * console.log(formatTVInfo(5, 120)); // "5 Seasons"
+ * console.log(formatTVInfo(0, 0));   // "N/A"
+ * console.log(formatTVInfo(1, 1));   // "1 Episodes"
+ *
+ * @example
+ * // Use in TV show card component
+ * function TVShowCard({ show, details }) {
+ *   const tvInfo = details ? formatTVInfo(details.number_of_seasons, details.number_of_episodes) : 'N/A';
+ *
+ *   return (
+ *     <div className="tv-show-card">
+ *       <h3>{show.name}</h3>
+ *       <p>{tvInfo}</p>
+ *     </div>
+ *   );
+ * }
+ *
+ * @example
+ * // Filter shows by season count
+ * const longRunningShows = tvShows.filter(show => {
+ *   const details = getMediaDetails(show);
+ *   return details && details.number_of_seasons >= 5;
+ * });
+ */
+export function formatTVInfo(seasons: number, episodes: number): string {
+  if (seasons === 0 && episodes === 0) return 'N/A';
+
+  if (seasons === 1) {
+    return `${episodes} Episodes`;
+  }
+
+  return `${seasons} Seasons`;
+}
+
+/**
+ * Returns formatted duration information based on media type
+ *
+ * @function getFormattedDuration
+ * @description Intelligently formats duration information based on media type,
+ * automatically selecting between movie runtime formatting and TV show season/episode
+ * formatting. Provides a unified interface for displaying duration across different
+ * media types with proper fallback handling for missing data.
+ *
+ * @param {any} mediaDetails - The media details object containing type and duration information
+ *
+ * @returns {string} Formatted duration string appropriate for the media type
+ *
+ * @example
+ * // Format duration for mixed media types
+ * const mediaItems = [movieDetails, tvShowDetails];
+ * mediaItems.forEach(details => {
+ *   console.log(`Duration: ${getFormattedDuration(details)}`);
+ * });
+ * // Output: "Duration: 2h 15m" (movie)
+ * // Output: "Duration: 3 Seasons" (TV show)
+ *
+ * @example
+ * // Use in universal media component
+ * function MediaDurationDisplay({ mediaDetails }) {
+ *   const duration = getFormattedDuration(mediaDetails);
+ *
+ *   return (
+ *     <span className="media-duration">
+ *       {duration}
+ *     </span>
+ *   );
+ * }
+ *
+ * @example
+ * // Filter media by duration
+ * function filterByDuration(mediaList: AnyMedia[], minDuration: number) {
+ *   return mediaList.filter(media => {
+ *     const details = getMediaDetails(media);
+ *     if (!details) return false;
+ *
+ *     if (details.mediaType === 'movie') {
+ *       return details.runtime >= minDuration;
+ *     } else {
+ *       return details.number_of_seasons >= Math.ceil(minDuration / 60);
+ *     }
+ *   });
+ * }
+ */
+export function getFormattedDuration(mediaDetails: any): string {
+  if (!mediaDetails) return 'N/A';
+
+  const { mediaType } = mediaDetails;
+
+  if (mediaType === 'movie') {
+    return mediaDetails.runtime ? formatRuntime(mediaDetails.runtime) : 'N/A';
+  } else {
+    return mediaDetails.number_of_seasons
+      ? formatTVInfo(mediaDetails.number_of_seasons, mediaDetails.number_of_episodes)
+      : 'N/A';
+  }
+}
+
+/**
+ * Gets detailed information for a specific media item
+ *
+ * @function getMediaDetails
+ * @description Retrieves cached detailed information for a specific media item by ID.
+ * Provides fast access to previously fetched media details without additional API
+ * calls. Returns null if the media details haven't been fetched yet, allowing
+ * components to handle loading states appropriately.
+ *
+ * @param {AnyMedia} media - The media item to get details for
+ *
+ * @returns {any | null} The detailed information object or null if not available in cache
+ *
+ * @example
+ * // Get details for a single media item
+ * const media = { id: 12345, name: 'Example Movie', media_type: 'movie' };
+ * const details = getMediaDetails(media);
+ *
+ * if (details) {
+ *   console.log(`Rating: ${details.contentRating}`);
+ *   console.log(`Runtime: ${formatRuntime(details.runtime)}`);
+ * } else {
+ *   console.log('Details not yet loaded');
+ * }
+ *
+ * @example
+ * // Use in React component with loading state
+ * function MediaDetailsComponent({ media }) {
+ *   const details = getMediaDetails(media);
+ *
+ *   if (!details) {
+ *     return <div>Loading details...</div>;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <h3>{media.name}</h3>
+ *       <p>Rating: {details.contentRating}</p>
+ *       <p>Duration: {getFormattedDuration(details)}</p>
+ *       <p>Genres: {details.genres.map(g => g.name).join(', ')}</p>
+ *     </div>
+ *   );
+ * }
+ *
+ * @example
+ * // Batch check for cached details
+ * function getAvailableDetails(mediaList: AnyMedia[]) {
+ *   return mediaList
+ *     .map(media => ({ media, details: getMediaDetails(media) }))
+ *     .filter(item => item.details !== null);
+ * }
+ */
+export function getMediaDetails(media: AnyMedia): any {
+  return detailsCache.get(media.id) || null;
+}

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -1,9 +1,20 @@
 /**
- * Media Service Module
+ * Media Service System
  *
  * @module
- * @description Provides functions for fetching and manipulating media data from the TMDB API.
- * Handles API requests, error handling, and data transformation for media-related operations.
+ * @description Provides comprehensive service functions for fetching and manipulating media data
+ * from the TMDB API throughout the application. Handles API requests, error handling,
+ * data transformation, and type mapping for all media-related operations. Ensures consistent
+ * data flow between the external API and internal application state with proper error management
+ * and data filtering.
+ *
+ * The service includes functions for:
+ * - Category-based media fetching with filtering and transformation
+ * - Top-rated media retrieval with ranking assignment
+ * - Random media selection for featured content
+ * - API response mapping to application types
+ * - Error handling and logging with global state updates
+ * - Data filtering to ensure quality content display
  *
  * @requires module:@constants
  * @requires ./apiService
@@ -40,13 +51,39 @@ import { createMedia, filterDataWithBackdrops } from '@utils';
  *
  * @async
  * @function fetchMediaByCategory
- * @description Retrieves media data from TMDB API for a specific category
+ * @description Retrieves media data from TMDB API for a specific category with comprehensive
+ * error handling and data transformation. Filters results to ensure only media with backdrop
+ * images are included, maps API responses to application types, and assigns appropriate
+ * type discriminators. Provides robust error handling with global error state updates.
  *
  * @param {string} category - The category key from the ENDPOINTS object (e.g., 'fetchNetflixOriginals')
+ *
  * @returns {Promise<AnyMedia[]>} A promise that resolves to an array of media objects with backdrops
  *
+ * @throws {Error} Logs error to console and updates global error store, but returns empty array instead of throwing
+ *
  * @example
- * const medias = await fetchMediaByCategory('fetchNetflixOriginals');
+ * // Fetch Netflix Originals
+ * const netflixOriginals = await fetchMediaByCategory('fetchNetflixOriginals');
+ * console.log(`Found ${netflixOriginals.length} Netflix Originals`);
+ *
+ * @example
+ * // Fetch trending movies with error handling
+ * try {
+ *   const trendingMovies = await fetchMediaByCategory('fetchTrending');
+ *   if (trendingMovies.length > 0) {
+ *     updateMovieCarousel(trendingMovies);
+ *   }
+ * } catch (error) {
+ *   console.log('Error handled by service, empty array returned');
+ * }
+ *
+ * @example
+ * // Fetch multiple categories
+ * const categories = ['fetchActionMovies', 'fetchComedyMovies', 'fetchHorrorMovies'];
+ * const allMedia = await Promise.all(
+ *   categories.map(category => fetchMediaByCategory(category))
+ * );
  */
 export async function fetchMediaByCategory(category: string): Promise<AnyMedia[]> {
   try {
@@ -75,11 +112,36 @@ export async function fetchMediaByCategory(category: string): Promise<AnyMedia[]
  *
  * @async
  * @function fetchTopRatedMedia
- * @description Retrieves top rated medias from TMDB API, limits to 10 results,
- * sorts by vote_average, and assigns a rank property to each media
+ * @description Retrieves top rated medias from TMDB API with comprehensive ranking system.
+ * Filters results to ensure quality content, sorts by vote average in descending order,
+ * limits to top 10 results, and assigns rank properties (1-10) based on position.
+ * Transforms API responses to MediaRanked objects with proper type discrimination.
  *
  * @returns {Promise<MediaRanked[]>} A promise that resolves to an array of top 10 ranked medias
+ *
  * @throws {Error} Logs error to console and updates global error store, but returns empty array instead of throwing
+ *
+ * @example
+ * // Fetch top rated media for ranking display
+ * const topRatedMedia = await fetchTopRatedMedia();
+ * topRatedMedia.forEach(media => {
+ *   console.log(`#${media.rank}: ${media.name} (${media.vote_average})`);
+ * });
+ *
+ * @example
+ * // Use top rated media in ranking component
+ * const rankings = await fetchTopRatedMedia();
+ * if (rankings.length === 10) {
+ *   updateRankingCarousel(rankings);
+ * } else {
+ *   console.warn('Expected 10 ranked items, got:', rankings.length);
+ * }
+ *
+ * @example
+ * // Get top 3 media for featured section
+ * const topRated = await fetchTopRatedMedia();
+ * const topThree = topRated.slice(0, 3);
+ * displayFeaturedContent(topThree);
  */
 export async function fetchTopRatedMedia(): Promise<MediaRanked[]> {
   try {
@@ -118,17 +180,51 @@ export async function fetchTopRatedMedia(): Promise<MediaRanked[]> {
  * Gets a random media from an array of medias
  *
  * @function getRandomMedia
- * @description Selects a random media from the provided array of medias.
- * Returns null if the array is empty.
+ * @description Selects a random media from the provided array of medias using secure
+ * random number generation. Provides safe handling of empty arrays and ensures
+ * uniform distribution across all array elements. Commonly used for featured
+ * content selection and billboard displays.
  *
  * @param {AnyMedia[]} medias - Array of medias to select from
+ *
  * @returns {AnyMedia | null} A randomly selected media or null if the array is empty
  *
  * @example
  * // Get a random media for the billboard
+ * const netflixOriginals = await fetchMediaByCategory('fetchNetflixOriginals');
  * const featuredMedia = getRandomMedia(netflixOriginals);
  * if (featuredMedia) {
  *   billboardMedia.set(featuredMedia);
+ * }
+ *
+ * @example
+ * // Get random media with fallback
+ * function selectFeaturedContent(mediaArrays: AnyMedia[][]) {
+ *   for (const mediaArray of mediaArrays) {
+ *     const randomMedia = getRandomMedia(mediaArray);
+ *     if (randomMedia) {
+ *       return randomMedia;
+ *     }
+ *   }
+ *   return getDefaultMedia();
+ * }
+ *
+ * @example
+ * // Get multiple random media
+ * function getRandomSample(medias: AnyMedia[], count: number): AnyMedia[] {
+ *   const sample: AnyMedia[] = [];
+ *   const availableMedia = [...medias];
+ *
+ *   for (let i = 0; i < count && availableMedia.length > 0; i++) {
+ *     const randomMedia = getRandomMedia(availableMedia);
+ *     if (randomMedia) {
+ *       sample.push(randomMedia);
+ *       const index = availableMedia.indexOf(randomMedia);
+ *       availableMedia.splice(index, 1);
+ *     }
+ *   }
+ *
+ *   return sample;
  * }
  */
 export function getRandomMedia(medias: AnyMedia[]): AnyMedia | null {
@@ -144,11 +240,48 @@ export function getRandomMedia(medias: AnyMedia[]): AnyMedia | null {
  *
  * @function mapApiResponseToBaseMedia
  * @description Transforms the complete API response into the focused application type,
- * handling inconsistencies between movie and TV show properties
+ * handling inconsistencies between movie and TV show properties from the TMDB API.
+ * Normalizes field names, handles missing properties, and ensures consistent data
+ * structure across different media types. Provides robust mapping for both movies
+ * and TV shows with proper fallback values.
  *
- * @param {TMDBMediaResponse} response - Raw API response item
- * @param {MediaType} type - The media type discriminator
+ * @param {TMDBMediaResponse} response - Raw API response item from TMDB
+ * @param {MediaType} [type='standard'] - The media type discriminator to assign
+ *
  * @returns {AnyMedia} Properly typed media object for application use
+ *
+ * @example
+ * // Map movie API response
+ * const movieResponse = {
+ *   id: 12345,
+ *   title: 'Example Movie',
+ *   original_title: 'Original Movie Title',
+ *   overview: 'Movie description',
+ *   backdrop_path: '/backdrop.jpg',
+ *   poster_path: '/poster.jpg',
+ *   vote_average: 8.5,
+ *   media_type: 'movie'
+ * };
+ * const movieMedia = mapApiResponseToBaseMedia(movieResponse);
+ *
+ * @example
+ * // Map TV show API response
+ * const tvResponse = {
+ *   id: 67890,
+ *   name: 'Example TV Show',
+ *   original_name: 'Original TV Show Name',
+ *   overview: 'TV show description',
+ *   backdrop_path: '/tv_backdrop.jpg',
+ *   poster_path: '/tv_poster.jpg',
+ *   vote_average: 9.2,
+ *   media_type: 'tv'
+ * };
+ * const tvMedia = mapApiResponseToBaseMedia(tvResponse);
+ *
+ * @example
+ * // Map with custom type discriminator
+ * const rankedMedia = mapApiResponseToBaseMedia(apiResponse, 'ranked');
+ * console.log(rankedMedia.type); // 'ranked'
  */
 function mapApiResponseToBaseMedia(
   response: TMDBMediaResponse,
@@ -156,6 +289,8 @@ function mapApiResponseToBaseMedia(
 ): AnyMedia {
   // Handle the name/title inconsistency
   const displayName = response.name || response.title || '';
+  const mediaType =
+    response.media_type || (response.title || response.original_title ? 'movie' : 'tv');
   const originalName = response.original_name || response.original_title || '';
 
   // Base media properties used across the application
@@ -163,6 +298,7 @@ function mapApiResponseToBaseMedia(
     type,
     backdrop_path: response.backdrop_path,
     id: response.id,
+    media_type: mediaType,
     name: displayName,
     original_name: originalName,
     overview: response.overview,

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,3 +1,23 @@
+/**
+ * Media System Type Definitions
+ *
+ * @module
+ * @description Provides comprehensive type definitions for the media system throughout
+ * the application. Defines interfaces and types for media objects, component props,
+ * store configurations, and ranking systems. Ensures type safety and consistency across
+ * all media-related components, stores, and utilities in the application.
+ *
+ * The module includes type definitions for:
+ * - Base media interfaces with TMDB API compatibility
+ * - Media type discrimination and union types
+ * - Component prop interfaces for media items and carousels
+ * - Store interfaces for media data management
+ * - Ranking system types with SVG rendering support
+ * - Progress tracking for watched media content
+ *
+ * @requires svelte/store
+ */
+
 import type { Writable } from 'svelte/store';
 
 /**
@@ -9,23 +29,24 @@ export type AnyMedia = Media | MediaRanked | MediaWatched;
  * Represents a media object from the TMDB API
  *
  * @interface BaseMedia
- * @property {MediaType} type - Discriminator field to identify the media type
  * @property {string|null} backdrop_path - Path to the backdrop image
  * @property {number} id - Unique identifier for the media
  * @property {string} name - name of the media
  * @property {string} original_name - Original name of the media
  * @property {string} overview - Brief description of the media
  * @property {string|null} poster_path - Path to the media poster image
+ * @property {MediaType} type - Discriminator field to identify the media type
  * @property {number} vote_average - Average vote rating
  */
 export interface BaseMedia {
-  type: MediaType;
   backdrop_path: string | null;
   id: number;
+  media_type: 'movie' | 'tv';
   name: string;
   original_name: string;
   overview: string;
   poster_path: string | null;
+  type: MediaType;
   vote_average: number;
 }
 
@@ -47,6 +68,18 @@ export interface BaseMediaItemProps {
 }
 
 /**
+ * Genre information for media content
+ *
+ * @interface Genre
+ * @property {number} id - Genre identifier
+ * @property {string} name - Genre name
+ */
+export interface Genre {
+  id: number;
+  name: string;
+}
+
+/**
  * Standard media interface
  *
  * @interface Media
@@ -54,6 +87,22 @@ export interface BaseMediaItemProps {
  */
 export interface Media extends BaseMedia {
   type: 'standard';
+}
+
+/**
+ * Collection information for movies
+ *
+ * @interface MediaCollection
+ * @property {number} id - Collection identifier
+ * @property {string} name - Collection name
+ * @property {string} poster_path - Collection poster image path
+ * @property {string} backdrop_path - Collection backdrop image path
+ */
+export interface MediaCollection {
+  id: number;
+  name: string;
+  poster_path: string;
+  backdrop_path: string;
 }
 
 /**
@@ -66,6 +115,34 @@ export interface Media extends BaseMedia {
 export interface MediaContent {
   data: AnyMedia | null;
   width: number;
+}
+
+/**
+ * Media details interface for processed media information
+ *
+ * @interface MediaDetails
+ * @description Represents the processed media details structure containing
+ * content rating, genre information, runtime details, and collection data.
+ * Handles both movie and TV show specific properties with proper nullability.
+ *
+ * @property {MediaCollection|null} belongs_to_collection - Collection information for movies, null for TV shows or standalone movies
+ * @property {string} contentRating - Content rating (e.g., "PG-13", "TV-14", "R")
+ * @property {Genre[]} genres - Array of genre objects
+ * @property {string|undefined} mediaTitleType - Media title type for TV shows, undefined for movies
+ * @property {"movie"|"tv"} mediaType - Type of media content
+ * @property {number|null} number_of_episodes - Number of episodes for TV shows, null for movies
+ * @property {number|null} number_of_seasons - Number of seasons for TV shows, null for movies
+ * @property {number|null} runtime - Runtime in minutes for movies, null for TV shows
+ */
+export interface MediaDetails {
+  belongs_to_collection: MediaCollection | null;
+  contentRating: string;
+  genres: Genre[];
+  mediaTitleType: string | undefined;
+  mediaType: 'movie' | 'tv';
+  number_of_episodes: number | null;
+  number_of_seasons: number | null;
+  runtime: number | null;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
 
       // Non-wildcard paths for barrel file imports
       "@constants": ["src/constants"],
+      "@services": ["src/services"],
       "@stores": ["src/stores"],
       "@types": ["src/types"],
       "@utils": ["src/utils"]


### PR DESCRIPTION
This PR builds the `mediaDetailsService` for fetching details for specific media titles. This includes:
- Adding a services barrel file
- Adding `media_type` to `mapApiResponseToBaseMedia`
- Updating media types

Additionally, this PR adds/improves documentation for `mediaService` and media types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized location for importing all service modules, simplifying imports.
  * Introduced a comprehensive service for batch fetching, caching, and formatting detailed media information, with utility functions for duration and TV info formatting.

* **Enhancements**
  * Improved type definitions for media-related data, adding new interfaces for genres, collections, and detailed media info.
  * Expanded and clarified documentation across service and type modules for better usability and maintainability.

* **Chores**
  * Updated TypeScript configuration to support a new import alias for services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->