### PR TITLE
Update manifest app root to match github pages subpath

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,16 +3,16 @@
   "short_name": "Svelte Netflix",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "/netflix-svelte/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "/netflix-svelte/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
   "display": "standalone",
-  "start_url": "/"
+  "start_url": "/netflix-svelte/"
 }


### PR DESCRIPTION
The manifest `start_url` was never updated to apply the `/netflix-svelte/` subpath required for deployment to GitHub Pages. This PR fixes that, including also prefixing the `src` urls for the `icons` accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app icon paths and start URL in the web app manifest to reflect new asset locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->