### PR TITLE
Update :global row class with media- prefix

### DIFF
--- a/src/components/slider/RowHeader.svelte
+++ b/src/components/slider/RowHeader.svelte
@@ -148,7 +148,7 @@
   }
 
   /* Hover states */
-  :global(.row:hover) .row__title .row__explore-chevron {
+  :global(.media-row:hover) .row__title .row__explore-chevron {
     display: inline-block;
     font-size: 0.9vw;
   }


### PR DESCRIPTION
[This commit](https://github.com/scottgilmoredev/netflix-svelte/commit/8fb4d5841239babeceb46fe7ca89d972be7312eb) changed the `row` class to `media-row`. This change was not applied to the `:global` instance of the glass in the `RowHeader` component, causing the "Explore All" chevron to remain hidden on hover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the hover effect so that the chevron icon is now shown only when hovering over elements with the `.media-row` class, rather than all `.row` elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->